### PR TITLE
Fix page title

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,7 +15,7 @@
     %meta{property: 'fb:admins', content: "716316740"}
     %meta{property: 'fb:app_id', content: "106874206377516"}
 
-    %title content_for(:title) || "Ruby Heroes"
+    %title= content_for(:title) || "Ruby Heroes"
     %link{rel: 'shortcut icon', type: 'image/png', href: image_path('favicon.png') }
     = stylesheet_link_tag 'application'
 


### PR DESCRIPTION
Hi @olivierlacan 

I noticed that the page title is not properly set.

![rubyheroes-page-title](https://cloud.githubusercontent.com/assets/50518/16707529/34481b68-45d2-11e6-9bab-54a45752101c.png)

Here is a tiny fix.

m2c
